### PR TITLE
Using manifests for v2.9.6

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.9.6/manifests/install.yaml
 
 configMapGenerator:
   - name: argocd-cm

--- a/manifests/ha/kustomization.yaml
+++ b/manifests/ha/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.9.6/manifests/ha/install.yaml
 
 configMapGenerator:
   - name: argocd-cm


### PR DESCRIPTION
Due to issues raised with v.2.10.0, pinning version to 2.9.6

https://github.com/argoproj/argo-cd/issues/17016