### PR TITLE
Upgrading argocd manifests to v3.3.5

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.2.1/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.5/manifests/install.yaml
 
 configMapGenerator:
   - name: argocd-cm

--- a/manifests/ha/kustomization.yaml
+++ b/manifests/ha/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.2.1/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.5/manifests/ha/install.yaml
 
 configMapGenerator:
   - name: argocd-cm


### PR DESCRIPTION
[DEVOPS-1550]

[DEVOPS-1550]: https://vikingcloud.atlassian.net/browse/DEVOPS-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the Argo CD upstream install manifests, which can change deployed controllers/RBAC/CRDs and behavior at runtime; rollout should be validated in a cluster before promotion.
> 
> **Overview**
> Updates the Argo CD Kustomize bases to pull upstream manifests from `argoproj/argo-cd` **v3.3.5** instead of **v3.2.1** for both the standard (`manifests/base/kustomization.yaml`) and HA (`manifests/ha/kustomization.yaml`) installs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb30bfd84da969c2fb4dcd9b670ac467a4322a73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->