### PR TITLE
Updating argocd manifests to 3.4.3

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.5/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.3/manifests/install.yaml
 
 configMapGenerator:
   - name: argocd-cm

--- a/manifests/ha/kustomization.yaml
+++ b/manifests/ha/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.5/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.3/manifests/ha/install.yaml
 
 configMapGenerator:
   - name: argocd-cm


### PR DESCRIPTION
[DEVOPS-1550]

[DEVOPS-1550]: https://vikingcloud.atlassian.net/browse/DEVOPS-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the GitOps control plane via upstream manifests; rollout impact depends on Argo CD 3.4.x release notes and cluster apply order, though this repo only changes version pins.
> 
> **Overview**
> Bumps the upstream Argo CD install manifests from **v3.3.5** to **v3.4.3** for both deployment flavors: the standard overlay in `manifests/base/kustomization.yaml` and the HA overlay in `manifests/ha/kustomization.yaml`. Only the remote `resources` URLs change; existing kustomize behavior (merged `argocd-cm` reconciliation timeout and ClusterRoleBinding namespace patch) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f77aaf6544ea1a732502abcd363852e92854f9d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->